### PR TITLE
fix: fix for temporary errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
-            type=semver,pattern={{major}},enable=${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
+            type=semver,pattern=v{{major}},enable=${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
           images: |
             ghcr.io/cresta/atlantis-drift-detection
       - name: Build and push

--- a/action.yml
+++ b/action.yml
@@ -7,4 +7,4 @@ runs:
   using: 'docker'
   # TODO: Figure out a way to auto update this. It's very useful for speeding up the action to not have it build the
   # container each run
-  image: 'docker://ghcr.io/cresta/atlantis-drift-detection:v0.0.11'
+  image: 'docker://ghcr.io/cresta/atlantis-drift-detection:v1'

--- a/cmd/atlantis-drift-detection/main.go
+++ b/cmd/atlantis-drift-detection/main.go
@@ -3,6 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"time"
+
 	"github.com/cresta/atlantis-drift-detection/internal/atlantis"
 	"github.com/cresta/atlantis-drift-detection/internal/drifter"
 	"github.com/cresta/atlantis-drift-detection/internal/notification"
@@ -11,9 +15,6 @@ import (
 	"github.com/cresta/gogit"
 	"github.com/cresta/gogithub"
 	"github.com/joho/godotenv"
-	"net/http"
-	"os"
-	"time"
 
 	// Empty import allows pinning to version atlantis uses
 	_ "github.com/nlopes/slack"
@@ -100,7 +101,11 @@ func main() {
 		logger.Info("setting up slack webhook notification")
 		notif.Notifications = append(notif.Notifications, slackClient)
 	}
-	ghClient, err := gogithub.NewGQLClient(ctx, logger, nil)
+	var existingConfig *gogithub.NewGQLClientConfig
+	if os.Getenv("GITHUB_TOKEN") != "" {
+		existingConfig = &gogithub.NewGQLClientConfig{Token: os.Getenv("GITHUB_TOKEN")}
+	}
+	ghClient, err := gogithub.NewGQLClient(ctx, logger, existingConfig)
 	if err != nil {
 		logger.Panic("failed to create github client", zap.Error(err))
 	}

--- a/internal/notification/multi.go
+++ b/internal/notification/multi.go
@@ -6,6 +6,15 @@ type Multi struct {
 	Notifications []Notification
 }
 
+func (m *Multi) TemporaryError(ctx context.Context, dir string, workspace string, err error) error {
+	for _, n := range m.Notifications {
+		if err := n.TemporaryError(ctx, dir, workspace, err); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (m *Multi) ExtraWorkspaceInRemote(ctx context.Context, dir string, workspace string) error {
 	for _, n := range m.Notifications {
 		if err := n.ExtraWorkspaceInRemote(ctx, dir, workspace); err != nil {

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -22,4 +22,6 @@ type Notification interface {
 	ExtraWorkspaceInRemote(ctx context.Context, dir string, workspace string) error
 	MissingWorkspaceInRemote(ctx context.Context, dir string, workspace string) error
 	PlanDrift(ctx context.Context, dir string, workspace string) error
+	// TemporaryError is called when an error occurs but we can't really tell what it means
+	TemporaryError(ctx context.Context, dir string, workspace string, err error) error
 }

--- a/internal/notification/slackwebhook.go
+++ b/internal/notification/slackwebhook.go
@@ -13,6 +13,10 @@ type SlackWebhook struct {
 	HTTPClient *http.Client
 }
 
+func (s *SlackWebhook) TemporaryError(ctx context.Context, dir string, workspace string, err error) error {
+	return s.sendSlackMessage(ctx, fmt.Sprintf("Unknown error in remote\nDirectory: %s\nWorkspace: %s\nError: %s", dir, workspace, err.Error()))
+}
+
 func NewSlackWebhook(webhookURL string, HTTPClient *http.Client) *SlackWebhook {
 	if webhookURL == "" {
 		return nil

--- a/internal/notification/workflow.go
+++ b/internal/notification/workflow.go
@@ -2,8 +2,9 @@ package notification
 
 import (
 	"context"
-	"github.com/cresta/gogithub"
 	"sync"
+
+	"github.com/cresta/gogithub"
 )
 
 func NewWorkflow(ghClient gogithub.GitHub, owner string, repo string, id string, ref string) *Workflow {
@@ -30,11 +31,16 @@ type Workflow struct {
 	directoriesDone map[string]struct{}
 }
 
-func (w *Workflow) ExtraWorkspaceInRemote(ctx context.Context, dir string, workspace string) error {
+func (w *Workflow) TemporaryError(_ context.Context, _ string, _ string, _ error) error {
+	// Ignored
 	return nil
 }
 
-func (w *Workflow) MissingWorkspaceInRemote(ctx context.Context, dir string, workspace string) error {
+func (w *Workflow) ExtraWorkspaceInRemote(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (w *Workflow) MissingWorkspaceInRemote(_ context.Context, _ string, _ string) error {
 	return nil
 }
 

--- a/internal/notification/zap.go
+++ b/internal/notification/zap.go
@@ -2,11 +2,17 @@ package notification
 
 import (
 	"context"
+
 	"go.uber.org/zap"
 )
 
 type Zap struct {
 	Logger *zap.Logger
+}
+
+func (I *Zap) TemporaryError(_ context.Context, dir string, workspace string, err error) error {
+	I.Logger.Error("Unknown error in remote", zap.String("dir", dir), zap.String("workspace", workspace), zap.Error(err))
+	return nil
 }
 
 func (I *Zap) PlanDrift(_ context.Context, dir string, workspace string) error {


### PR DESCRIPTION
The atlantis API isn't very graceful when errors
happen.  Best we can do is log it and move on.
