### PR TITLE
fix: [cresta/atlantis-drift-detection#27] hardcoded master ref

### DIFF
--- a/cmd/atlantis-drift-detection/main.go
+++ b/cmd/atlantis-drift-detection/main.go
@@ -16,11 +16,11 @@ import (
 	"github.com/cresta/gogithub"
 	"github.com/joho/godotenv"
 
+	"github.com/joeshaw/envdecode"
 	// Empty import allows pinning to version atlantis uses
 	_ "github.com/nlopes/slack"
 	"go.uber.org/zap"
 )
-import "github.com/joeshaw/envdecode"
 
 type config struct {
 	Repo               string        `env:"REPO,required"`
@@ -35,7 +35,7 @@ type config struct {
 	WorkflowOwner      string        `env:"WORKFLOW_OWNER"`
 	WorkflowRepo       string        `env:"WORKFLOW_REPO"`
 	WorkflowId         string        `env:"WORKFLOW_ID"`
-	WorkflowRef        string        `env:"WORKFLOW_REF"`
+	WorkflowRef        string        `env:"WORKFLOW_REF,default=master"`
 }
 
 func loadEnvIfExists() error {
@@ -130,6 +130,7 @@ func main() {
 		DirectoryWhitelist: cfg.DirectoryWhitelist,
 		Logger:             logger.With(zap.String("drifter", "true")),
 		Repo:               cfg.Repo,
+		Ref:                cfg.WorkflowRef,
 		AtlantisClient: &atlantis.Client{
 			AtlantisHostname: cfg.AtlantisHostname,
 			Token:            cfg.AtlantisToken,

--- a/internal/drifter/drifter.go
+++ b/internal/drifter/drifter.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/cresta/atlantis-drift-detection/internal/atlantis"
 	"github.com/cresta/atlantis-drift-detection/internal/atlantisgithub"
 	"github.com/cresta/atlantis-drift-detection/internal/notification"
@@ -13,13 +16,12 @@ import (
 	"github.com/cresta/gogithub"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	"os"
-	"time"
 )
 
 type Drifter struct {
 	Logger             *zap.Logger
 	Repo               string
+	Ref                string
 	Cloner             *gogit.Cloner
 	GithubClient       gogithub.GitHub
 	Terraform          *terraform.Client
@@ -144,7 +146,7 @@ func (d *Drifter) FindDriftedWorkspaces(ctx context.Context, ws atlantis.Directo
 
 				pr, err := d.AtlantisClient.PlanSummary(ctx, &atlantis.PlanSummaryRequest{
 					Repo:      d.Repo,
-					Ref:       "master",
+					Ref:       d.Ref,
 					Type:      "Github",
 					Dir:       dir,
 					Workspace: workspace,


### PR DESCRIPTION
Fixes https://github.com/cresta/atlantis-drift-detection/issues/27.

I didn't spend a ton of time reading the code base but I think `WORKFLOW_REF` in [cmd/atlantis-drift-detection/main.go#L38](https://github.com/cresta/atlantis-drift-detection/blob/17accd8e8112b64e40ddb286e53b5ab454237684/cmd/atlantis-drift-detection/main.go#L38) is what was intended to be used to configure the base branch ref.

This PR:
1. updates the `Drifter` struct to include a `Ref` field
2. uses the `WORKFLOW_REF` env var from the main `config` struct for the `Drifter` ref
3. Sets a default `master` string if `WORKFLOW_REF` env var is not configured
4. `go fmt .../` changed the imports but that looks like a good change so I didn't revert it

If the `WORKFLOW_REF` env var isn't intended to be coupled, I can edit this PR and pull from a new env var but could use guidance on what the env var name should be.